### PR TITLE
Update docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ minicron
 [![Coverage Status](http://img.shields.io/coveralls/jamesrwhite/minicron.svg)](https://coveralls.io/r/jamesrwhite/minicron?branch=master)
 [![Code Climate](http://img.shields.io/codeclimate/github/jamesrwhite/minicron.svg)](https://codeclimate.com/github/jamesrwhite/minicron)
 [![Dependency Status](http://img.shields.io/gemnasium/jamesrwhite/minicron.svg)](https://gemnasium.com/jamesrwhite/minicron)
-[![Inline docs](http://inch-pages.github.io/github/jamesrwhite/minicron.png)](http://inch-pages.github.io/github/jamesrwhite/minicron)
+[![Inline docs](http://inch-ci.org/github/jamesrwhite/minicron.png)](http://inch-ci.org/github/jamesrwhite/minicron)
 
 minicron aims to complement ````cron```` by making it easier to manage and monitor cron jobs, it can largely be
 thought of as two components that interact together, the CLI and the Hub. The CLI is what is installed on your


### PR DESCRIPTION
Hi there,

this patch updates the URL of the docs badge in your README. Inch's badges will be served from it's own CI service http://inch-ci.org in the future and I will slowly retire the old [Inch Pages project](http://inch-pages.github.io/). 

With the new service, people can [add projects straight from the homepage](http://inch-ci.org/) and also [configure a webhook to rebuild](http://inch-ci.org/howto/webhook) their badges auto-magically :star2:

I am so happy that Inch and Inch Pages were so well received in the community and that I am now able to keep [my promise](http://trivelop.de/2014/02/24/visibility-of-documentation/) to deliver a real, [open source](https://github.com/inch-ci) web service for the badges.

P.S. I have not written an announcement or anything for this. **But**: Everybody who reads this is invited to add their projects to the site. Please help me find the last bugs, so I can start writing the "Introducing Inch CI" blog post :wink:
