### PR TITLE
Upgrade to rspec 3.0! \o/

### DIFF
--- a/minicron.gemspec
+++ b/minicron.gemspec
@@ -49,6 +49,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.1'
-  spec.add_development_dependency 'rspec', '~> 2.1'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.8'
 end

--- a/spec/minicron/alert/pagerduty_spec.rb
+++ b/spec/minicron/alert/pagerduty_spec.rb
@@ -59,7 +59,7 @@ describe Minicron::PagerDuty do
     it 'should trigger an alert on the pagerduty client' do
       pagerduty = Minicron::PagerDuty.new
 
-      pagerduty.instance_variable_get(:@client).should_receive(:trigger).with('title', :message => 'yo')
+      expect(pagerduty.instance_variable_get(:@client)).to receive(:trigger).with('title', :message => 'yo')
 
       pagerduty.send('title', 'yo')
     end

--- a/spec/minicron/transport/client_spec.rb
+++ b/spec/minicron/transport/client_spec.rb
@@ -46,7 +46,7 @@ describe Minicron::Transport::Client do
     it 'should call #publish with the correct params' do
       client = Minicron::Transport::Client.new('http', 'example.com', 99, '/')
 
-      client.should_receive(:publish).with('/job/1/2/output', 'test')
+      expect(client).to receive(:publish).with('/job/1/2/output', 'test')
 
       client.send(
         :job_id => 1,
@@ -60,7 +60,7 @@ describe Minicron::Transport::Client do
   describe '#publish' do
     it 'should call #request with the correct params' do
       client = Minicron::Transport::Client.new('https', 'test.com', 139, '/test')
-      client.stub(:request)
+      allow(client).to receive(:request)
 
       json = { :channel => '/job/1/2/status', :data => {
         :ts => Time.now.utc.strftime('%Y-%m-%d %H:%M:%S'),
@@ -68,7 +68,7 @@ describe Minicron::Transport::Client do
         :seq => 1
       } }.to_json
 
-      client.should_receive(:request).with(:message => json)
+      expect(client).to receive(:request).with(:message => json)
 
       client.publish('/job/1/2/status', 'test')
 

--- a/spec/minicron/transport/faye/client_spec.rb
+++ b/spec/minicron/transport/faye/client_spec.rb
@@ -14,11 +14,11 @@ describe Minicron::Transport::FayeClient do
   end
 
   describe '#ensure_delivery' do
-    before(:each) { eventmachine.stub(:stop) }
+    before(:each) { allow(eventmachine).to receive(:stop) }
 
     it 'should block until the queue hash is empty and return nil' do
       client_instance = client.new('http', '127.0.0.1', '80', '/test')
-      client_instance.stub(:queue).and_return({ :a => 1 }, { :a => 1, :b => 2 }, { :b => 2 }, {})
+      allow(client_instance).to receive(:queue).and_return({ :a => 1 }, { :a => 1, :b => 2 }, { :b => 2 }, {})
 
       client_instance.ensure_delivery
       expect(client_instance.queue.length).to eq 0
@@ -50,8 +50,8 @@ describe Minicron::Transport::FayeClient do
   describe '#tidy_up' do
     context 'when eventmachine is running' do
       it 'should stop eventmachine' do
-        eventmachine.should_receive(:reactor_running?).and_return true
-        eventmachine.should_receive(:stop)
+        expect(eventmachine).to receive(:reactor_running?).and_return true
+        expect(eventmachine).to receive(:stop)
 
         client.new('http', '127.0.0.1', '80', '/test').tidy_up
       end
@@ -59,7 +59,7 @@ describe Minicron::Transport::FayeClient do
 
     context 'when eventmachine is not running' do
       it 'should do nothing' do
-        eventmachine.should_receive(:reactor_running?).and_return false
+        expect(eventmachine).to receive(:reactor_running?).and_return false
 
         client.new('http', '127.0.0.1', '80', '/test').tidy_up
       end

--- a/spec/minicron/transport/server_spec.rb
+++ b/spec/minicron/transport/server_spec.rb
@@ -8,8 +8,8 @@ describe Minicron::Transport::Server do
   describe '#start!' do
     context 'when the server is running' do
       it 'should return false' do
-        server.stub(:server).and_return thin_server
-        server.should_receive(:running?).and_return true
+        allow(server).to receive(:server).and_return thin_server
+        expect(server).to receive(:running?).and_return true
 
         expect(server.start!('127.0.0.1', 1337, '/lol')).to eq false
       end
@@ -17,9 +17,9 @@ describe Minicron::Transport::Server do
 
     context 'when the server is not running' do
       it 'should return true' do
-        server.should_receive(:running?).and_return false
-      	thin_server.should_receive(:new).and_return thin_server
-        thin_server.stub(:start)
+        expect(server).to receive(:running?).and_return false
+      	expect(thin_server).to receive(:new).and_return thin_server
+        allow(thin_server).to receive(:start)
 
         expect(server.start!('127.0.0.1', 1337, '/lol')).to eq true
       end
@@ -30,7 +30,7 @@ describe Minicron::Transport::Server do
     context 'when the server is not running' do
       it 'should return false' do
         server.server = nil
-        server.should_receive(:running?).and_return false
+        expect(server).to receive(:running?).and_return false
 
         expect(server.stop!).to eq false
       end
@@ -39,8 +39,8 @@ describe Minicron::Transport::Server do
     context 'when the server is running' do
       it 'should return true' do
         server.server = thin_server
-        server.should_receive(:running?).and_return true
-        thin_server.should_receive(:stop).and_return true
+        expect(server).to receive(:running?).and_return true
+        expect(thin_server).to receive(:stop).and_return true
 
         expect(server.stop!).to eq true
       end
@@ -58,7 +58,7 @@ describe Minicron::Transport::Server do
     context 'when the server is running' do
       it 'should return true' do
         server.server = thin_server
-        thin_server.should_receive(:running?).and_return true
+        expect(thin_server).to receive(:running?).and_return true
 
         expect(server.running?).to eq true
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ require 'minicron'
 require 'minicron/cli'
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
   config.formatter     = 'documentation'
 
   # Taken from commander gem


### PR DESCRIPTION
- changed 2.99 rspec to 3.0
- changed some specs to expect/allow syntax
- `#color_enabled` config replaced by `#color`

http://myronmars.to/n/dev-blog/2014/06/rspec-2-99-0-and-3-0-0-have-been-released
