### PR TITLE
Adds pid_file config.

### DIFF
--- a/bin/minicron
+++ b/bin/minicron
@@ -21,7 +21,7 @@ rescue Interrupt, SignalException
   puts "\nExiting.."
 
   # Stop the daemon if it's running i.e tidy up the pid file
-  insidious = Insidious.new(:pid_file => '/tmp/minicron.pid')
+  insidious = Insidious.new(:pid_file => Minicron.config['server']['pid_file'] || '/tmp/minicron.pid')
 
   if insidious.running?
     insidious.stop!

--- a/lib/minicron/cli.rb
+++ b/lib/minicron/cli.rb
@@ -40,7 +40,8 @@ module Minicron
           'host' => opts.host,
           'port' => opts.port,
           'path' => opts.path,
-          'debug' => opts.debug
+          'debug' => opts.debug,
+          'pid_file' => opts.pid_file
         }
       )
     end

--- a/lib/minicron/cli/commands.rb
+++ b/lib/minicron/cli/commands.rb
@@ -52,12 +52,14 @@ module Minicron
 
       # Add the `minicron server` command
       def self.add_server_cli_command(cli)
+        default_pid_file = '/tmp/minicron.pid'
         cli.command :server do |c|
           c.syntax = 'minicron server [start|stop|restart|status]'
           c.description = 'Controls the minicron server.'
           c.option '--host STRING', String, "The host for the server to listen on. Default: #{Minicron.config['server']['host']}"
           c.option '--port STRING', Integer, "How port for the server to listed on. Default: #{Minicron.config['server']['port']}"
           c.option '--path STRING', String, "The path on the host. Default: #{Minicron.config['server']['path']}"
+          c.option '--pid_file STRING', String, "The path for daemon's PID file. Default: #{Minicron.config['server']['pid_file'] || default_pid_file}"
           c.option '--debug', "Enable debug mode. Default: #{Minicron.config['server']['debug']}"
 
           c.action do |args, opts|
@@ -69,7 +71,7 @@ module Minicron
 
             # Get an instance of insidious and set the pid file
             insidious = Insidious.new(
-              :pid_file => '/tmp/minicron.pid',
+              :pid_file => Minicron.config['server']['pid_file'] || default_pid_file,
               :daemonize => Minicron.config['server']['debug'] == false
             )
 

--- a/spec/minicron_spec.rb
+++ b/spec/minicron_spec.rb
@@ -77,7 +77,8 @@ describe Minicron do
             'host' => '127.0.0.1',
             'port' => 9292,
             'path' => '/',
-            'debug' => false
+            'debug' => false,
+            'pid_file' => '/tmp/minicron.pid'
           },
           'database' => {
             'type' => 'sqlite'

--- a/spec/valid_config.toml
+++ b/spec/valid_config.toml
@@ -19,6 +19,7 @@ host = "127.0.0.1"
 port = 9292
 path = "/"
 debug = false
+pid_file = "/tmp/minicron.pid"
 
 # Database options
 [database]


### PR DESCRIPTION
This adds a `pid_file` config under the `server` group (see #86). Defaults to `/tmp/minicron.pid`.
