### PR TITLE
Fixed Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,12 @@ FROM phusion/baseimage:0.9.16
 MAINTAINER James White <dev.jameswhite+minicron@gmail.com>
 
 # Install Ruby and minicron build dependencies
-RUN apt-get install -y ruby libsqlite3-dev ruby-dev build-essential less
+RUN apt-get update && apt-get install -y \
+  ruby \
+  libsqlite3-dev \
+  ruby-dev \
+  build-essential \
+  less
 
 # Install minicron
 RUN gem install --no-ri --no-rdoc minicron


### PR DESCRIPTION
You need to run `apt-get update` before installing the packages so they can be found:

    E: Unable to locate package ruby
    E: Unable to locate package libsqlite3-dev
    E: Unable to locate package ruby-dev
    E: Unable to locate package build-essential