### PR TITLE
delete all schedules when deleting a job

### DIFF
--- a/lib/minicron/hub/controllers/jobs.rb
+++ b/lib/minicron/hub/controllers/jobs.rb
@@ -123,7 +123,7 @@ class Minicron::Hub::App
   post '/job/:id/delete' do
     begin
       # Look up the job
-      @job = Minicron::Hub::Job.find(params[:id])
+      @job = Minicron::Hub::Job.includes(:schedules).find(params[:id])
 
       Minicron::Hub::Job.transaction do
         # Try and delete the job


### PR DESCRIPTION
Fixes #157

This is to delete all the associated schedules tied to a job when you delete a job. If you delete a schedule individually, it works just fine, but https://github.com/jamesrwhite/minicron/blob/3d33ddabca874d4ade027116678b1dcfaae9de39/lib/minicron/cron.rb#L232-L234 these lines aren't effective because the schedules aren't loaded so `job.schedules.length` is always 0. I tested this on my own setup and it worked.

I would've written some tests, but it doesn't look like Hub tests are implemented just yet :/

@jamesrwhite 