### PR TITLE
[CONFIG]  Updated sample configuration file to include necessary section

### DIFF
--- a/config/minicron.toml
+++ b/config/minicron.toml
@@ -15,6 +15,14 @@ inactivity_timeout = 5
   [client.cli]
   mode = "line" # [line, char] - line by line output or char by char
   dry_run = false # When true the command is run but not sent to the server
+  [client.server]  # The settings in this section identify the hub 
+                   # server that the minicron client should connect to when
+                   # running `minicron run` on a client instance/machine/VM.
+  scheme = "http" # [http, https]
+  host = "127.0.0.1"
+  port = 9292
+  path = "/"
+  
 
 # Server options
 [server]


### PR DESCRIPTION
In order for the minicron client to connect to a hub server, there needs
to be a section defined in the configuration file for `client.server` that
specifies the values for `scheme`, `host`, `path` and `port`.  The use of these
values can be seen in `lib/minicron/cli/commands.rb`.  This commit updates the
sample configuration file to specify these needed values so that users do not
see a weird error message.