### PR TITLE
add explicit ordering of outputs and executions

### DIFF
--- a/lib/minicron/hub/controllers/executions.rb
+++ b/lib/minicron/hub/controllers/executions.rb
@@ -2,7 +2,7 @@ class Minicron::Hub::App
   get '/execution/:id' do
     # Look up the job execution
     @execution = Minicron::Hub::Execution.includes(:job_execution_outputs, :job => :host)
-                                         .order(:created_at => :desc, :started_at => :desc)
+                                         .order('job_execution_outputs.seq')
                                          .find(params[:id])
 
     erb :'executions/show', :layout => :'layouts/app'

--- a/lib/minicron/hub/controllers/jobs.rb
+++ b/lib/minicron/hub/controllers/jobs.rb
@@ -11,7 +11,9 @@ class Minicron::Hub::App
 
   get '/job/:id' do
     # Look up the job
-    @job = Minicron::Hub::Job.includes(:host, :executions, :schedules).find(params[:id])
+    @job = Minicron::Hub::Job.includes(:host, :executions, :schedules)
+                             .order('executions.number DESC')
+                             .find(params[:id])
 
     erb :'jobs/show', :layout => :'layouts/app'
   end


### PR DESCRIPTION
### What

Add explicit ordering of:

* `job_execution_outputs` on the executions show page
* `executions` on the jobs show page

### Why

This is because certain DBs (like postgres) doesn't guarantee an inherent ordering of queries unless it has been explicitly declared.

### Notes

I removed `:created_at => :desc, :started_at => :desc` from the ordering of executions because these were sorting on the `executions` columns, but then we do a `.find` so the sorting was unnecessary.