### PR TITLE
Make it possible to run install script as root user 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,15 @@ VERSION="0.8.4"
 echo "Installing mincron v$VERSION"
 echo "OS input as $OS"
 
+echo "Checking user authorization"
+SUDO="sudo"
+if [[ "$EUID" -eq "0" ]]; then #is root
+	SUDO=""
+elif ! hash sudo 2>/dev/null; then # no sudo
+	echo "This script needs to be run as root user or sudo to be installed. Aborting ..."
+	exit
+fi
+
 DOWNLOAD_FILE="https://github.com/jamesrwhite/minicron/releases/download/v$VERSION/minicron-$VERSION-$OS.zip"
 # DOWNLOAD_FILE="http://localhost:8000/minicron-$VERSION-$OS.zip"
 TMP_ZIP_LOCATION="/tmp/minicron-$VERSION-$OS.zip"
@@ -23,16 +32,16 @@ echo "Removing archive $TMP_ZIP_LOCATION"
 rm $TMP_ZIP_LOCATION
 
 echo "Removing $LIB_LOCATION and creating $LIB_LOCATION (may require password)"
-sudo rm -rf $LIB_LOCATION && sudo mkdir -p /opt/minicron
+$SUDO rm -rf $LIB_LOCATION && $SUDO mkdir -p /opt/minicron
 
 echo "Moving $TMP_DIR_LOCATION to $LIB_LOCATION (may require password)"
-sudo mv $TMP_DIR_LOCATION/* $LIB_LOCATION
+$SUDO mv $TMP_DIR_LOCATION/* $LIB_LOCATION
 
 echo "Removing $TMP_DIR_LOCATION"
 rm -rf $TMP_DIR_LOCATION
 
 echo "Removing $BIN_LOCATION and linking $BIN_LOCATION to $LIB_LOCATION/minicron (may require password)"
-sudo rm -f $BIN_LOCATION && sudo ln -s $LIB_LOCATION/minicron $BIN_LOCATION
+$SUDO rm -f $BIN_LOCATION && $SUDO ln -s $LIB_LOCATION/minicron $BIN_LOCATION
 
 echo
 echo "done!"


### PR DESCRIPTION
I was giving minicron a try and had already problems to install it with the install.sh script, because i don't use sudo on the used system.

With this pull request i add support for running the install.sh script as root user. It puts an error if there is neither sudo available nor the current user is root and aborts the script.