### PR TITLE
Avoid many delete and high cpu

### DIFF
--- a/lib/minicron/hub/models/execution.rb
+++ b/lib/minicron/hub/models/execution.rb
@@ -4,7 +4,7 @@ module Minicron
   module Hub
     class Execution < ActiveRecord::Base
       belongs_to :job
-      has_many :job_execution_outputs, :dependent => :destroy
+      has_many :job_execution_outputs, :dependent => :delete_all
       has_many :alerts, :dependent => :destroy
 
       validates :job_id, :presence => true, :numericality => { :only_integer => true }


### PR DESCRIPTION
````
.... 500 delete before ....
D, [2016-03-30T06:16:25.905753 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112830]]
D, [2016-03-30T06:16:25.944773 #14122] DEBUG -- :   SQL (0.4ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112831]]
D, [2016-03-30T06:16:25.945878 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112832]]
D, [2016-03-30T06:16:25.946767 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112833]]
D, [2016-03-30T06:16:25.948042 #14122] DEBUG -- :   SQL (0.3ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112834]]
D, [2016-03-30T06:16:25.949175 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112835]]
D, [2016-03-30T06:16:25.950311 #14122] DEBUG -- :   SQL (0.3ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112836]]
D, [2016-03-30T06:16:25.951284 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112837]]
D, [2016-03-30T06:16:25.952060 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112838]]
D, [2016-03-30T06:16:25.952939 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112839]]
D, [2016-03-30T06:16:25.953866 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112840]]
D, [2016-03-30T06:16:25.954664 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112841]]
D, [2016-03-30T06:16:25.955800 #14122] DEBUG -- :   SQL (0.3ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112842]]
D, [2016-03-30T06:16:25.956687 #14122] DEBUG -- :   SQL (0.2ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112843]]
D, [2016-03-30T06:16:25.957585 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112844]]
D, [2016-03-30T06:16:25.958649 #14122] DEBUG -- :   SQL (0.2ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112845]]
D, [2016-03-30T06:16:25.959411 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112846]]
D, [2016-03-30T06:16:25.960405 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112847]]
D, [2016-03-30T06:16:25.961253 #14122] DEBUG -- :   SQL (0.1ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112848]]
D, [2016-03-30T06:16:25.962222 #14122] DEBUG -- :   SQL (0.2ms)  DELETE FROM "job_execution_outputs" WHERE "job_execution_outputs"."id" = ?  [["id", 112849]]
.... 500 delete after ....
```

Today when I try to delete a old job or an execution the minicron top my CPU