### PR TITLE
git tag was missing the `v` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ instead.
 You can also run minicron in a docker container, see below for instructions how:
 
 ````bash
-docker pull jamesrwhite/minicron:0.9.5
-minicron_container_id=$(docker run -d -p 127.0.0.1:9292:9292 -i -t jamesrwhite/minicron:0.9.5)
+docker pull jamesrwhite/minicron:v0.9.5
+minicron_container_id=$(docker run -d -p 127.0.0.1:9292:9292 -i -t jamesrwhite/minicron:v0.9.5)
 docker exec $minicron_container_id minicron db setup
 docker exec $minicron_container_id minicron server start
 ````


### PR DESCRIPTION
Trying the pull the image without using the proper tag for the release results in an error.

I just corrected the tags used in the documentation so others don't run into the same issue.