### PR TITLE
add basic auth support for the client

### DIFF
--- a/config/minicron.toml
+++ b/config/minicron.toml
@@ -9,6 +9,8 @@ debug = false # Useful for debugging
   [client.server]
   scheme = "http" # [http, https]
   host = "127.0.0.1"
+  username = "user" # optional for basic auth
+  password = "p@ssw0rd" # optional for basic auth
   port = 9292
   path = "/"
   connect_timeout = 5

--- a/lib/minicron/cli/commands.rb
+++ b/lib/minicron/cli/commands.rb
@@ -178,6 +178,8 @@ module Minicron
               client = Minicron::Transport::Client.new(
                 Minicron.config['client']['server']['scheme'],
                 Minicron.config['client']['server']['host'],
+                Minicron.config['client']['server']['username'],
+                Minicron.config['client']['server']['password'],
                 Minicron.config['client']['server']['port'],
                 Minicron.config['client']['server']['path']
               )

--- a/lib/minicron/transport/client.rb
+++ b/lib/minicron/transport/client.rb
@@ -7,9 +7,11 @@ module Minicron
       # Instantiate a new instance of the client
       #
       # @param host [String] The host to be communicated with
-      def initialize(scheme, host, port, path)
+      def initialize(scheme, host, username, password, port, path)
         @scheme = scheme
         @host = host
+        @username = username
+        @password = password
         @path = path == '/' ? '/api/v1' : "#{path}/api/v1"
         @port = port
         @seq = 1
@@ -148,6 +150,7 @@ module Minicron
         # Create a POST requests
         uri = URI("#{@scheme}://#{@host}:#{@port}#{@path}#{method}")
         post = Net::HTTP::Post.new(uri.path)
+        post.basic_auth @username, @password if @username || @password
         post.set_form_data(data)
 
         # Execute the POST request, TODO: error handling


### PR DESCRIPTION
For those running the minicron server behind a proxy with basic auth enabled, the client needs to be able to pass in the credentials. I tried just making the `host` config `user:pass@host.com`, but that didn't work. Since not everyone needs basic auth, I made it optional.

It doesn't look like there are any client tests though, so I couldn't add to it.

@jamesrwhite let me know if there's anything I should add!