### PR TITLE
fix(jobs): change job command input field to textarea

### DIFF
--- a/lib/minicron/hub/views/jobs/edit.erb
+++ b/lib/minicron/hub/views/jobs/edit.erb
@@ -13,7 +13,7 @@
   <div class="form-group">
     <label class="col-sm-2 control-label">Command</label>
     <div class="col-sm-10">
-      <input name="command" type="text" value="<%= @job[:command] %>" class="form-control" placehoder="What command should the job run"/>
+      <textarea name="command" rows="6" class="form-control" placeholder="What command should the job run"><%= @job[:command] %></textarea>
     </div>
   </div>
   <div class="form-group">


### PR DESCRIPTION
### What
This PR changes the [edit job view](https://github.com/jamesrwhite/minicron/blob/686c81ae082470e103126633ef6e43f6215089f1/lib/minicron/hub/views/jobs/edit.erb) to make use of a textarea tag instead of an input tag for the job command field. 

### Why
The command doesn't have any HTML escaping and therefore might cut short the value displayed in the input tag. For example, if the command of a job was `command "some text"`, the displayed HTML command would be `command ` as the `value` property of the input tag was closed by the double quote in the command value, causing the rest of the command to be added as attributes to the input field. I considered escaping the HTML and displaying the entire command in an input field but that meant that when saving the command all HTML entities would now be stored as escaped HTML rather than their characters. A textarea seemed better suited for the job and provided the additional benefit of the command input being re-sizeable. 

Overall this change has two benefits: 1) the cron job command is now fully displayed and is able to be edited by the user without having to re-enter the entire command and 2) users can make use of the resize textbox feature built-in by browsers to increase the textarea size if the command doesn't fit in the default textarea size.

#### Screenshots

- Original command information displayed for context
<img width="760" alt="screen shot 2016-10-09 at 3 55 13 pm" src="https://cloud.githubusercontent.com/assets/3803621/19224461/57e42010-8e3b-11e6-9425-953778c0c3a8.png">

- Truncated job command caused by this issue
<img width="758" alt="screen shot 2016-10-09 at 3 56 28 pm" src="https://cloud.githubusercontent.com/assets/3803621/19224464/74e8fb7c-8e3b-11e6-872a-6ed61c1af86d.png">

- Complete job shown as displayed with proposed changes 
<img width="754" alt="screen shot 2016-10-09 at 3 56 03 pm" src="https://cloud.githubusercontent.com/assets/3803621/19224466/86b30e24-8e3b-11e6-9b95-18a91a7d951b.png">




